### PR TITLE
Update AWS secret names to match convention, e.g. /dvp/* and use of "lab" instead of "sandbox"

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -38,7 +38,7 @@ if [ "${DEBUG:-false}" == "true" ]; then export DEBUG; fi
 #
 # PINGDOM_TOKEN will be used by the pingdom script as the Pingdom API key.
 #
-export PINGDOM_TOKEN=$(get-secret "/monitoring/pingdom-token")
+export PINGDOM_TOKEN=$(get-secret "/dvp/monitoring/pingdom-token")
 
 #
 # Load secrets early to make sure we have all the secrets we need before attempting to
@@ -47,7 +47,7 @@ export PINGDOM_TOKEN=$(get-secret "/monitoring/pingdom-token")
 # NOTE: AWS Systems Manager secret naming convention <env>/<product>/<key-name>
 #
 
-export HEALTH_APIS_STATIC_ACCESS_TOKEN=$(get-secret "/production/health/static-access-token")
+export HEALTH_APIS_STATIC_ACCESS_TOKEN=$(get-secret "/dvp/production/health/static-access-token")
 
 
 #
@@ -57,7 +57,7 @@ export HEALTH_APIS_STATIC_ACCESS_TOKEN=$(get-secret "/production/health/static-a
 
 
 if [ -f ./secrets.conf ]; then
-  TEST_SLACK_CHANNEL_ID=$(get-secret "/local/slack-integration/id")
+  TEST_SLACK_CHANNEL_ID=$(get-secret "/dvp/local/slack-integration/id")
 fi
 
 export TEST_SLACK_CHANNEL_ID

--- a/pingdom-checks/address-validation.ping
+++ b/pingdom-checks/address-validation.ping
@@ -1,5 +1,5 @@
-SANDBOX_ADDRESS_VALIDATION_API_KEY=$(get-secret "/sandbox/address-validation/api-key")
-PRODUCTION_ADDRESS_VALIDATION_API_KEY=$(get-secret "/production/address-validation/api-key")
+SANDBOX_ADDRESS_VALIDATION_API_KEY=$(get-secret "/dvp/lab/address-validation/api-key")
+PRODUCTION_ADDRESS_VALIDATION_API_KEY=$(get-secret "/dvp/production/address-validation/api-key")
 ADDRESS_VALIDATION_SLACK_ID=$TEST_SLACK_CHANNEL_ID
 
 pingdom save-check \

--- a/pingdom-checks/appeals.ping
+++ b/pingdom-checks/appeals.ping
@@ -1,5 +1,5 @@
-PRODUCTION_APPEALS_API_KEY=$(get-secret "/production/appeals/api-key")
-SANDBOX_APPEALS_API_KEY=$(get-secret "/sandbox/appeals/api-key")
+PRODUCTION_APPEALS_API_KEY=$(get-secret "/dvp/production/appeals/api-key")
+SANDBOX_APPEALS_API_KEY=$(get-secret "/dvp/lab/appeals/api-key")
 
 #v0
 pingdom save-check \

--- a/pingdom-checks/claims.ping
+++ b/pingdom-checks/claims.ping
@@ -1,5 +1,5 @@
-PRODUCTION_CLAIMS_API_KEY=$(get-secret "/production/claims/api-key")
-SANDBOX_CLAIMS_API_KEY=$(get-secret "/sandbox/claims/api-key")
+PRODUCTION_CLAIMS_API_KEY=$(get-secret "/dvp/production/claims/api-key")
+SANDBOX_CLAIMS_API_KEY=$(get-secret "/dvp/lab/claims/api-key")
 
 # v0
 pingdom save-check \

--- a/pingdom-checks/community-care.ping
+++ b/pingdom-checks/community-care.ping
@@ -1,4 +1,4 @@
-COMMUNITY_CARE_DEV_API_KEY=$(get-secret "/dev/community-care/api-key")
+COMMUNITY_CARE_DEV_API_KEY=$(get-secret "/dvp/dev/community-care/api-key")
 
 
 pingdom save-check \

--- a/pingdom-checks/documents.ping
+++ b/pingdom-checks/documents.ping
@@ -1,5 +1,5 @@
-PRODUCTION_DOCUMENTS_API_KEY=$(get-secret "/production/documents/api-key")
-SANDBOX_DOCUMENTS_API_KEY=$(get-secret "/sandbox/documents/api-key")
+PRODUCTION_DOCUMENTS_API_KEY=$(get-secret "/dvp/production/documents/api-key")
+SANDBOX_DOCUMENTS_API_KEY=$(get-secret "/dvp/lab/documents/api-key")
 
 #v0
 pingdom save-check \

--- a/pingdom-checks/facilities.ping
+++ b/pingdom-checks/facilities.ping
@@ -1,5 +1,5 @@
-SANDBOX_FACILITIES_API_KEY=$(get-secret "/sandbox/facilities/api-key")
-PRODUCTION_FACILITIES_API_KEY=$(get-secret "/production/facilities/api-key")
+SANDBOX_FACILITIES_API_KEY=$(get-secret "/dvp/lab/facilities/api-key")
+PRODUCTION_FACILITIES_API_KEY=$(get-secret "/dvp/production/facilities/api-key")
 FACILITIES_SLACK_ID=$TEST_SLACK_CHANNEL_ID
 
 pingdom save-check \

--- a/pingdom-checks/oauth.ping
+++ b/pingdom-checks/oauth.ping
@@ -1,7 +1,7 @@
-PRODUCTION_OAUTH_BASIC_AUTH_TOKEN=$(get-secret "/production/oauth/basic-auth-token")
-PRODUCTION_OAUTH_REFRESH_TOKEN=$(get-secret "/production/oauth/refresh-token")
-DEV_OAUTH_BASIC_AUTH_TOKEN=$(get-secret "/dev/oauth/basic-auth-token")
-DEV_OAUTH_REFRESH_TOKEN=$(get-secret "/dev/oauth/refresh-token")
+PRODUCTION_OAUTH_BASIC_AUTH_TOKEN=$(get-secret "/dvp/production/oauth/basic-auth-token")
+PRODUCTION_OAUTH_REFRESH_TOKEN=$(get-secret "/dvp/production/oauth/refresh-token")
+DEV_OAUTH_BASIC_AUTH_TOKEN=$(get-secret "/dvp/dev/oauth/basic-auth-token")
+DEV_OAUTH_REFRESH_TOKEN=$(get-secret "/dvp/dev/oauth/refresh-token")
 OAUTH_SLACK_ID=$TEST_SLACK_CHANNEL_ID
 
 pingdom save-check \


### PR DESCRIPTION
AWS parameters using the new names have already be added.
old entries still exist and will be deleted after this PR is merged.