### PR TITLE
Edit vet confirmation pingdom check for request-with-apiKey template

### DIFF
--- a/pingdom-checks/veteran-confirmation.ping
+++ b/pingdom-checks/veteran-confirmation.ping
@@ -1,24 +1,35 @@
+PRODUCTION_VETERAN_CONFIRMATION_API_KEY=$(get-secret "/dvp/production/veteran-confirmation/api-key")
+SANDBOX_VETERAN_CONFIRMATION_API_KEY=$(get-secret "/dvp/lab/veteran-confirmation/api-key")
+DEV_VETERAN_CONFIRMATION_API_KEY=$(get-secret "/dvp/dev/veteran-confirmation/api-key")
+
 #production
 pingdom save-check \
-  --template simple-resource \
+  --template request-with-apikey \
   -a name=production-veteran-confirmation-health \
   -a host=api.va.gov \
   -a url="/services/veteran_confirmation/v0/health" \
+  -a apiKey="$PRODUCTION_VETERAN_CONFIRMATION_API_KEY" \
+  -a userids_csv="$NO_USERS" \
   -a group=veteran-confirmation \
   -a integrationids_csv="$HEALTH_APIS_SLACK_ID"
+
 #sandbox
 pingdom save-check \
-  --template simple-resource \
+  --template request-with-apikey \
   -a name=sandbox-veteran-confirmation-health \
   -a host=sandbox-api.va.gov \
   -a url="/services/veteran_confirmation/v0/health" \
+  -a apiKey="$SANDBOX_VETERAN_CONFIRMATION_API_KEY" \
+  -a userids_csv="$NO_USERS" \
   -a group=veteran-confirmation \
   -a integrationids_csv="$HEALTH_APIS_SLACK_ID"
 # dev
 pingdom save-check \
-  --template simple-resource \
+  --template request-with-apikey \
   -a name=dev-veteran-confirmation-health \
   -a host=dev-api.va.gov \
   -a url="/services/veteran_confirmation/v0/health" \
+  -a apiKey="$DEV_VETERAN_CONFIRMATION_API_KEY" \
+  -a userids_csv="$NO_USERS" \
   -a group=veteran-confirmation \
   -a integrationids_csv="$HEALTH_APIS_SLACK_ID"


### PR DESCRIPTION
with apiKey at the kong level, the vet confirmation pingdom check will not work with the `simple-resource` template, edit for `request-with-apiKey`
related story: https://vasdvp.atlassian.net/browse/PIV-323