### PR TITLE
Shank 588 enable pager duty notifications

### DIFF
--- a/integration-ids.conf
+++ b/integration-ids.conf
@@ -13,14 +13,16 @@
 export NO_INTEGRATIONS=" "
 
 #
+# ~~ Slack ~~
 # A test channel that is not actively monitored by operations personnel
 # This is the `shanktovoid` channel in the Liberty Slack
 #
 export TEST_SLACK_CHANNEL_ID=100586
+export VASDVP_MONITORING=86071
 
 #
+# ~~ Pager Duty ~~
 # A test pager duty service integratoin that is not actively monitored by operations personnel
 #
 export TEST_PAGER_DUTY=100838
-
-
+export PAGER_DUTY=86691

--- a/pingdom-checks/api-gateway.ping
+++ b/pingdom-checks/api-gateway.ping
@@ -3,6 +3,8 @@
 PRODUCTION_API_GATEWAY_KEY=$(get-secret "/dvp/production/api-gateway/api-key")
 SANDBOX_API_GATEWAY_KEY=$(get-secret "/dvp/lab/api-gateway/api-key")
 
+GATEWAY_SLACK_ID=$VASDVP_MONITORING
+
 pingdom save-check \
   --template request-with-apikey \
   -a name=production-api-gateway-health-check \
@@ -11,7 +13,7 @@ pingdom save-check \
   -a apikey="$PRODUCTION_API_GATEWAY_KEY" \
   -a group="api-gateway" \
   -a userids_csv="$STATUSPAGE_PRODUCTION_API_GATEWAY" \
-  -a integrationids_csv="$HEALTH_APIS_SLACK_ID"
+  -a integrationids_csv="$GATEWAY_SLACK_ID,$PAGER_DUTY"
 
 pingdom save-check \
   --template request-with-apikey \
@@ -21,4 +23,4 @@ pingdom save-check \
   -a apikey="$SANDBOX_API_GATEWAY_KEY" \
   -a group="api-gateway" \
   -a userids_csv="$STATUSPAGE_SANDBOX_API_GATEWAY" \
-  -a integrationids_csv="$HEALTH_APIS_SLACK_ID"
+  -a integrationids_csv="$GATEWAY_SLACK_ID,$PAGER_DUTY"

--- a/pingdom-checks/community-care.ping
+++ b/pingdom-checks/community-care.ping
@@ -2,6 +2,7 @@
 
 COMMUNITY_CARE_DEV_API_KEY=$(get-secret "/dvp/dev/community-care/api-key")
 
+COMMUNITY_CARE_SLACK_ID=$VASDVP_MONITORING
 
 pingdom save-check \
   --template request-with-bearer-token \
@@ -11,7 +12,7 @@ pingdom save-check \
   -a group="community-care" \
   -a authorization_token="$HEALTH_APIS_STATIC_ACCESS_TOKEN" \
   -a userids_csv="$STATUSPAGE_PRODUCTION_COMMUNITY_CARE_ELIGIBILITY" \
-  -a integrationids_csv="$HEALTH_APIS_SLACK_ID"
+  -a integrationids_csv="$COMMUNITY_CARE_SLACK_ID,$PAGER_DUTY"
 
 pingdom save-check \
   --template request-with-bearer-token \
@@ -41,7 +42,7 @@ pingdom save-check \
   -a group="community-care" \
   -a authorization_token="$HEALTH_APIS_STATIC_ACCESS_TOKEN" \
   -a userids_csv="$STATUSPAGE_SANDBOX_COMMUNITY_CARE_ELIGIBILITY" \
-  -a integrationids_csv="$HEALTH_APIS_SLACK_ID"
+  -a integrationids_csv="$COMMUNITY_CARE_SLACK_ID,$PAGER_DUTY"
 
 pingdom save-check \
   --template request-with-apikey \
@@ -51,4 +52,4 @@ pingdom save-check \
   -a group="community-care" \
   -a apikey="$COMMUNITY_CARE_DEV_API_KEY" \
   -a userids_csv="$STATUSPAGE_SANDBOX_COMMUNITY_CARE_ELIGIBILITY" \
-  -a integrationids_csv="$HEALTH_APIS_SLACK_ID"
+  -a integrationids_csv="$COMMUNITY_CARE_SLACK_ID,$PAGER_DUTY"

--- a/pingdom-checks/data-query.ping
+++ b/pingdom-checks/data-query.ping
@@ -7,7 +7,7 @@ pingdom save-check \
   -a url="/services/fhir/v0/dstu2/Patient/1011537977V693883" \
   -a authorization_token="$HEALTH_APIS_STATIC_ACCESS_TOKEN" \
   -a userids_csv="$STATUSPAGE_PRODUCTION_FHIR" \
-  -a integrationids_csv="$HEALTH_APIS_SLACK_ID"
+  -a integrationids_csv="$HEALTH_APIS_SLACK_ID,$PAGER_DUTY"
 
 pingdom save-check \
   --template fhir-resource \
@@ -25,7 +25,7 @@ pingdom save-check \
   -a url="/services/fhir/v0/dstu2/MedicationStatement?patient=1011537977V693883" \
   -a authorization_token="$HEALTH_APIS_STATIC_ACCESS_TOKEN" \
   -a userids_csv="$STATUSPAGE_PRODUCTION_FHIR" \
-  -a integrationids_csv="$HEALTH_APIS_SLACK_ID"
+  -a integrationids_csv="$HEALTH_APIS_SLACK_ID,$PAGER_DUTY"
 
 pingdom save-check \
   --template simple-resource \
@@ -85,7 +85,7 @@ pingdom save-check \
   -a url="/services/fhir/v0/dstu2/Patient/1011537977V693883" \
   -a authorization_token="$HEALTH_APIS_STATIC_ACCESS_TOKEN" \
   -a userids_csv="$STATUSPAGE_SANDBOX_FHIR" \
-  -a integrationids_csv="$HEALTH_APIS_SLACK_ID"
+  -a integrationids_csv="$HEALTH_APIS_SLACK_ID,$PAGER_DUTY"
 
 pingdom save-check \
   --template fhir-resource \
@@ -103,4 +103,4 @@ pingdom save-check \
   -a url="/services/fhir/v0/dstu2/MedicationStatement?patient=1011537977V693883" \
   -a authorization_token="$HEALTH_APIS_STATIC_ACCESS_TOKEN" \
   -a userids_csv="$STATUSPAGE_SANDBOX_FHIR" \
-  -a integrationids_csv="$HEALTH_APIS_SLACK_ID"
+  -a integrationids_csv="$HEALTH_APIS_SLACK_ID,$PAGER_DUTY"

--- a/pingdom-checks/domain.ping
+++ b/pingdom-checks/domain.ping
@@ -1,4 +1,6 @@
-DOMAIN_SLACK_ID=$TEST_SLACK_CHANNEL_ID
+# -*- sh -*-
+
+DOMAIN_SLACK_ID=$VASDVP_MONITORING
 
 pingdom save-check \
   --template https-public-200 \
@@ -9,7 +11,7 @@ pingdom save-check \
   -a responsetime_threshold="30000" \
   -a resolution="1" \
   -a group="domain-health" \
-  -a integrationids_csv="$DOMAIN_SLACK_ID" \
+  -a integrationids_csv="$DOMAIN_SLACK_ID,$PAGER_DUTY" \
   -a userids_csv="$NO_USERS"
 
 pingdom save-check \
@@ -21,7 +23,7 @@ pingdom save-check \
   -a responsetime_threshold="30000" \
   -a resolution="1" \
   -a group="domain-health" \
-  -a integrationids_csv="$DOMAIN_SLACK_ID" \
+  -a integrationids_csv="$DOMAIN_SLACK_ID,$PAGER_DUTY" \
   -a userids_csv="$NO_USERS"
 
 pingdom save-check \
@@ -33,7 +35,7 @@ pingdom save-check \
   -a responsetime_threshold="30000" \
   -a resolution="1" \
   -a group="domain-health" \
-  -a integrationids_csv="$DOMAIN_SLACK_ID" \
+  -a integrationids_csv="$DOMAIN_SLACK_ID,$PAGER_DUTY" \
   -a userids_csv="$NO_USERS"
 
 pingdom save-check \
@@ -45,5 +47,5 @@ pingdom save-check \
   -a responsetime_threshold="30000" \
   -a resolution="1" \
   -a group="domain-health" \
-  -a integrationids_csv="$DOMAIN_SLACK_ID" \
+  -a integrationids_csv="$TEST_SLACK_CHANNEL_ID" \
   -a userids_csv="$NO_USERS"

--- a/pingdom-checks/facilities.ping
+++ b/pingdom-checks/facilities.ping
@@ -2,7 +2,8 @@
 
 SANDBOX_FACILITIES_API_KEY=$(get-secret "/dvp/lab/facilities/api-key")
 PRODUCTION_FACILITIES_API_KEY=$(get-secret "/dvp/production/facilities/api-key")
-FACILITIES_SLACK_ID=$TEST_SLACK_CHANNEL_ID
+FACILITIES_SLACK_ID=$VASDVP_MONITORING
+FACILITIES_BACKEND_SLACK_ID=$TEST_SLACK_CHANNEL_ID
 
 pingdom save-check \
   --template request-with-apikey \
@@ -12,7 +13,7 @@ pingdom save-check \
   -a group=facilities \
   -a apikey="$SANDBOX_FACILITIES_API_KEY" \
   -a userids_csv="$STATUSPAGE_SANDBOX_FACILITIES" \
-  -a integrationids_csv="$FACILITIES_SLACK_ID"
+  -a integrationids_csv="$FACILITIES_SLACK_ID,$PAGER_DUTY"
 
 pingdom save-check \
   --template request-with-apikey \
@@ -22,7 +23,7 @@ pingdom save-check \
   -a group=facilities \
   -a apikey="$SANDBOX_FACILITIES_API_KEY" \
   -a userids_csv="$NO_USERS" \
-  -a integrationids_csv="$FACILITIES_SLACK_ID"
+  -a integrationids_csv="$FACILITIES_SLACK_ID,$PAGER_DUTY"
 
 pingdom save-check \
   --template request-with-apikey \
@@ -32,7 +33,7 @@ pingdom save-check \
   -a group=facilities \
   -a apikey="$SANDBOX_FACILITIES_API_KEY" \
   -a userids_csv="$NO_USERS" \
-  -a integrationids_csv="$FACILITIES_SLACK_ID"
+  -a integrationids_csv="$TEST_SLACK_CHANNEL_ID"
 
 pingdom save-check \
   --template request-with-apikey \
@@ -42,7 +43,7 @@ pingdom save-check \
   -a group=facilities \
   -a apikey="$SANDBOX_FACILITIES_API_KEY" \
   -a userids_csv="$NO_USERS" \
-  -a integrationids_csv="$FACILITIES_SLACK_ID"
+  -a integrationids_csv="$TEST_SLACK_CHANNEL_ID"
 
 pingdom save-check \
   --template request-with-apikey \
@@ -52,7 +53,7 @@ pingdom save-check \
   -a group=facilities \
   -a apikey="$PRODUCTION_FACILITIES_API_KEY" \
   -a userids_csv="$STATUSPAGE_PRODUCTION_FACILITIES" \
-  -a integrationids_csv="$FACILITIES_SLACK_ID"
+  -a integrationids_csv="$FACILITIES_SLACK_ID,$PAGER_DUTY"
 
 pingdom save-check \
   --template request-with-apikey \
@@ -62,7 +63,7 @@ pingdom save-check \
   -a group=facilities \
   -a apikey="$PRODUCTION_FACILITIES_API_KEY" \
   -a userids_csv="$NO_USERS" \
-  -a integrationids_csv="$FACILITIES_SLACK_ID"
+  -a integrationids_csv="$FACILITIES_SLACK_ID,$PAGER_DUTY"
 
 #
 # Facilities Collector (Checks Backend Services)
@@ -76,7 +77,7 @@ pingdom save-check \
   -a group=facilities \
   -a apikey="$PRODUCTION_FACILITIES_API_KEY" \
   -a userids_csv="$NO_USERS" \
-  -a integrationids_csv="$FACILITIES_SLACK_ID"
+  -a integrationids_csv="$FACILITIES_BACKEND_SLACK_ID"
 
 pingdom save-check \
   --template request-with-apikey \
@@ -86,4 +87,4 @@ pingdom save-check \
   -a group=facilities \
   -a apikey="$SANDBOX_FACILITIES_API_KEY" \
   -a userids_csv="$NO_USERS" \
-  -a integrationids_csv="$FACILITIES_SLACK_ID"
+  -a integrationids_csv="$FACILITIES_BACKEND_SLACK_ID"

--- a/pingdom-checks/oauth.ping
+++ b/pingdom-checks/oauth.ping
@@ -1,8 +1,10 @@
+# -*- sh -*-
+
 PRODUCTION_OAUTH_BASIC_AUTH_TOKEN=$(get-secret "/dvp/production/oauth/basic-auth-token")
 PRODUCTION_OAUTH_REFRESH_TOKEN=$(get-secret "/dvp/production/oauth/refresh-token")
 DEV_OAUTH_BASIC_AUTH_TOKEN=$(get-secret "/dvp/dev/oauth/basic-auth-token")
 DEV_OAUTH_REFRESH_TOKEN=$(get-secret "/dvp/dev/oauth/refresh-token")
-OAUTH_SLACK_ID=$TEST_SLACK_CHANNEL_ID
+OAUTH_SLACK_ID=$VASDVP_MONITORING
 
 pingdom save-check \
   --template oauth-refresh-token \
@@ -11,7 +13,7 @@ pingdom save-check \
   -a url=/oauth2/token \
   -a authorization_token="$PRODUCTION_OAUTH_BASIC_AUTH_TOKEN" \
   -a refresh_token="$PRODUCTION_OAUTH_REFRESH_TOKEN" \
-  -a integrationids_csv="$OAUTH_SLACK_ID";
+  -a integrationids_csv="$OAUTH_SLACK_ID,$PAGER_DUTY";
 
 pingdom save-check \
   --template oauth-refresh-token \
@@ -20,7 +22,7 @@ pingdom save-check \
   -a url=/oauth2/token \
   -a authorization_token="$DEV_OAUTH_BASIC_AUTH_TOKEN" \
   -a refresh_token="$DEV_OAUTH_REFRESH_TOKEN" \
-  -a integrationids_csv="$OAUTH_SLACK_ID";
+  -a integrationids_csv="$TEST_SLACK_CHANNEL_ID";
 
   pingdom save-check \
     --template oauth-refresh-token \
@@ -29,4 +31,4 @@ pingdom save-check \
     -a url=/oauth2/token \
     -a authorization_token="$DEV_OAUTH_BASIC_AUTH_TOKEN" \
     -a refresh_token="$DEV_OAUTH_REFRESH_TOKEN" \
-    -a integrationids_csv="$OAUTH_SLACK_ID";
+    -a integrationids_csv="$OAUTH_SLACK_ID,$PAGER_DUTY";

--- a/pingdom-checks/saml-proxy.ping
+++ b/pingdom-checks/saml-proxy.ping
@@ -1,3 +1,7 @@
+# -*- sh -*-
+
+SAML_PROXY_SLACK_ID=$VASDVP_MONITORING
+
 #production
 pingdom save-check \
   --template simple-resource \
@@ -5,7 +9,7 @@ pingdom save-check \
   -a host=api.va.gov \
   -a url="/samlproxy/idp/metadata" \
   -a group=saml-proxy \
-  -a integrationids_csv="$HEALTH_APIS_SLACK_ID"
+  -a integrationids_csv="$SAML_PROXY_SLACK_ID,$PAGER_DUTY"
 
 #sandbox
 pingdom save-check \
@@ -14,7 +18,7 @@ pingdom save-check \
   -a host=sandbox-api.va.gov \
   -a url="/samlproxy/idp/metadata" \
   -a group=saml-proxy \
-  -a integrationids_csv="$HEALTH_APIS_SLACK_ID"
+  -a integrationids_csv="$SAML_PROXY_SLACK_ID,$PAGER_DUTY"
   
 # dev
 pingdom save-check \

--- a/pingdom-checks/urgent-care.ping
+++ b/pingdom-checks/urgent-care.ping
@@ -1,5 +1,7 @@
 # -*- sh -*-
 
+URGENT_CARE_SLACK_ID=$VASDVP_MONITORING
+
 pingdom save-check \
   --template fhir-resource \
   -a name=dev-r4-coverage-eligibility-response \
@@ -16,7 +18,7 @@ pingdom save-check \
   -a url="/services/fhir/v0/r4/CoverageEligibilityResponse?patient=1017283148V813263" \
   -a authorization_token="$HEALTH_APIS_STATIC_ACCESS_TOKEN" \
   -a userids_csv="$NO_USERS" \
-  -a integrationids_csv="$HEALTH_APIS_SLACK_ID"
+  -a integrationids_csv="$URGENT_CARE_SLACK_ID,$PAGER_DUTY"
 
 pingdom save-check \
   --template fhir-resource \
@@ -25,4 +27,4 @@ pingdom save-check \
   -a url="/services/fhir/v0/r4/CoverageEligibilityResponse?patient=1017237188V293031" \
   -a authorization_token="$HEALTH_APIS_STATIC_ACCESS_TOKEN" \
   -a userids_csv="$NO_USERS" \
-  -a integrationids_csv="$HEALTH_APIS_SLACK_ID"
+  -a integrationids_csv="$URGENT_CARE_SLACK_ID,$PAGER_DUTY"


### PR DESCRIPTION
https://vasdvp.atlassian.net/browse/SHANK-588

Talked to Gabriel, and for the checks planned for the `lh-apis-oncall` channel, he said we could move them to monitoring temporarily. I left out dq because we already get those checks in the monitoring channel.