### PR TITLE
replace /dvp/dev paths with /dvp/qa

### DIFF
--- a/pingdom-checks/community-care.ping
+++ b/pingdom-checks/community-care.ping
@@ -1,6 +1,6 @@
 # -*- sh -*-
 
-COMMUNITY_CARE_DEV_API_KEY=$(get-secret "/dvp/dev/community-care/api-key")
+COMMUNITY_CARE_DEV_API_KEY=$(get-secret "/dvp/qa/community-care/api-key")
 COMMUNITY_CARE_SLACK_ID=$VASDVP_MONITORING
 COMMUNITY_CARE_BACKEND_SLACK_ID=$TEST_SLACK_CHANNEL_ID
 

--- a/pingdom-checks/oauth.ping
+++ b/pingdom-checks/oauth.ping
@@ -2,8 +2,8 @@
 
 PRODUCTION_OAUTH_BASIC_AUTH_TOKEN=$(get-secret "/dvp/production/oauth/basic-auth-token")
 PRODUCTION_OAUTH_REFRESH_TOKEN=$(get-secret "/dvp/production/oauth/refresh-token")
-DEV_OAUTH_BASIC_AUTH_TOKEN=$(get-secret "/dvp/dev/oauth/basic-auth-token")
-DEV_OAUTH_REFRESH_TOKEN=$(get-secret "/dvp/dev/oauth/refresh-token")
+DEV_OAUTH_BASIC_AUTH_TOKEN=$(get-secret "/dvp/qa/oauth/basic-auth-token")
+DEV_OAUTH_REFRESH_TOKEN=$(get-secret "/dvp/qa/oauth/refresh-token")
 OAUTH_SLACK_ID=$VASDVP_MONITORING
 
 pingdom save-check \

--- a/pingdom-checks/veteran-confirmation.ping
+++ b/pingdom-checks/veteran-confirmation.ping
@@ -1,6 +1,6 @@
 PRODUCTION_VETERAN_CONFIRMATION_API_KEY=$(get-secret "/dvp/production/veteran-confirmation/api-key")
 SANDBOX_VETERAN_CONFIRMATION_API_KEY=$(get-secret "/dvp/lab/veteran-confirmation/api-key")
-DEV_VETERAN_CONFIRMATION_API_KEY=$(get-secret "/dvp/dev/veteran-confirmation/api-key")
+DEV_VETERAN_CONFIRMATION_API_KEY=$(get-secret "/dvp/qa/veteran-confirmation/api-key")
 
 #production
 pingdom save-check \


### PR DESCRIPTION
AWS parameter store secrets have been created to support the new paths.

Secrets corresponding to the old paths can be deleted when the change is successful.