### PR TITLE
API-4817 - Enable PagerDuty for Condition probe

### DIFF
--- a/pingdom-checks/data-query.ping
+++ b/pingdom-checks/data-query.ping
@@ -19,7 +19,7 @@ pingdom save-check \
   -a url="/services/fhir/v0/dstu2/Condition?patient=1011537977V693883" \
   -a authorization_token="$HEALTH_APIS_STATIC_ACCESS_TOKEN" \
   -a userids_csv="$STATUSPAGE_PRODUCTION_FHIR" \
-  -a integrationids_csv="$DATA_QUERY_SLACK_ID"
+  -a integrationids_csv="$DATA_QUERY_SLACK_ID,$PAGER_DUTY"
 
 pingdom save-check \
   --template fhir-resource \
@@ -74,7 +74,7 @@ pingdom save-check \
   -a url="/services/fhir/v0/dstu2/Condition?patient=1011537977V693883" \
   -a authorization_token="$HEALTH_APIS_STATIC_ACCESS_TOKEN" \
   -a userids_csv="$STATUSPAGE_SANDBOX_FHIR" \
-  -a integrationids_csv="$DATA_QUERY_SLACK_ID"
+  -a integrationids_csv="$DATA_QUERY_SLACK_ID,$PAGER_DUTY"
 
 pingdom save-check \
   --template fhir-resource \


### PR DESCRIPTION
Per API-4817, the Data Query Condition Pingdom probe does not have PagerDuty integration enabled. This PR resolves this issue.