### PR TITLE
API-11415: Adding pingdom probe for DVP Jenkins healthcheck

### DIFF
--- a/pingdom-checks/jenkins.ping
+++ b/pingdom-checks/jenkins.ping
@@ -14,4 +14,3 @@ pingdom save-check \
   -a resolution=1 \
   -a userids_csv="$NO_USERS" \
   -a integrationids_csv="$JENKINS_SLACK_ID"
-  

--- a/pingdom-checks/jenkins.ping
+++ b/pingdom-checks/jenkins.ping
@@ -14,3 +14,4 @@ pingdom save-check \
   -a resolution=1 \
   -a userids_csv="$NO_USERS" \
   -a integrationids_csv="$JENKINS_SLACK_ID"
+  

--- a/pingdom-checks/jenkins.ping
+++ b/pingdom-checks/jenkins.ping
@@ -1,0 +1,16 @@
+# -*- sh -*-
+
+JENKINS_SLACK_ID="$SLACK_VASDVP_MONITORING,$SLACK_API_ALARMS_JENKINS"
+
+pingdom save-check \
+  --template request-with-basic-auth \
+  -a name=dvp-jenkins-health-check \
+  -a host=tools.health.dev-developer.va.gov \
+  -a url="/jenkins/" \
+  -a port="443" \
+  -a username=$(get-secret /dvp/devops/jenkins_pingdom_user) \
+  -a password=$(get-secret /dvp/devops/jenkins_pingdom_user_password) \
+  -a responsetime_threshold=30000 \
+  -a resolution=1 \
+  -a userids_csv="$NO_USERS" \
+  -a integrationids_csv="$JENKINS_SLACK_ID"

--- a/templates/request-with-basic-auth.json
+++ b/templates/request-with-basic-auth.json
@@ -1,0 +1,19 @@
+{
+    "name": "$name",
+    "type": "http",
+    "host": "$host",
+    "port": 443,
+    "url": "$url",
+    "auth": "$username:$password",
+    "encryption": true,
+    "verify_certificate": true,
+    "resolution": 1,
+    "responsetime_threshold": 30000,
+    "sendnotificationwhendown": 6,
+    "notifyagainevery": 1,
+    "notifywhenbackup": true,
+    "tags": [ "$build", "managed", "$group" ],
+    "integrationids": [ $integrationids_csv ],
+    "userids" : [ $userids_csv ],
+    "probe_filters": [ "region: NA" ]
+  }

--- a/templates/request-with-basic-auth.json
+++ b/templates/request-with-basic-auth.json
@@ -16,4 +16,4 @@
     "integrationids": [ $integrationids_csv ],
     "userids" : [ $userids_csv ],
     "probe_filters": [ "region: NA" ]
-  }
+}


### PR DESCRIPTION
Adds a pingdom probe that checks the health status of DVP Jenkins by logging in with basic auth and hitting `/jenkins`. Includes template for requests with basic auth. 