### PR TITLE
API-16940 - Update CDW Alerts

### DIFF
--- a/pingdom-checks/data-query.ping
+++ b/pingdom-checks/data-query.ping
@@ -10,7 +10,7 @@ pingdom save-check \
   -a url="/services/fhir/v0/dstu2/Patient/1011537977V693883" \
   -a authorization_token="$HEALTH_APIS_STATIC_ACCESS_TOKEN" \
   -a userids_csv="$STATUSPAGE_PRODUCTION_FHIR" \
-  -a integrationids_csv="$DATA_QUERY_SLACK_ID,$PAGER_DUTY"
+  -a integrationids_csv="$DATA_QUERY_SLACK_ID,$PAGER_DUTY_DEPENDENCIES"
 
 pingdom save-check \
   --template fhir-resource \
@@ -19,7 +19,7 @@ pingdom save-check \
   -a url="/services/fhir/v0/dstu2/Condition?patient=1011537977V693883" \
   -a authorization_token="$HEALTH_APIS_STATIC_ACCESS_TOKEN" \
   -a userids_csv="$STATUSPAGE_PRODUCTION_FHIR" \
-  -a integrationids_csv="$DATA_QUERY_SLACK_ID,$PAGER_DUTY"
+  -a integrationids_csv="$DATA_QUERY_SLACK_ID,$PAGER_DUTY_DEPENDENCIES"
 
 pingdom save-check \
   --template fhir-resource \
@@ -28,7 +28,7 @@ pingdom save-check \
   -a url="/services/fhir/v0/dstu2/MedicationStatement?patient=1011537977V693883" \
   -a authorization_token="$HEALTH_APIS_STATIC_ACCESS_TOKEN" \
   -a userids_csv="$STATUSPAGE_PRODUCTION_FHIR" \
-  -a integrationids_csv="$DATA_QUERY_SLACK_ID,$PAGER_DUTY"
+  -a integrationids_csv="$DATA_QUERY_SLACK_ID,$PAGER_DUTY_DEPENDENCIES"
 
 pingdom save-check \
   --template simple-resource \


### PR DESCRIPTION
Per new guidance from the POs ( see https://vajira.max.gov/browse/API-16940 ) , the on-call team will not be paged immediately for every CDW blip moving forward. Even though we're authorized to only get alerted after a sustained 30-minute event, we'll be initially pursuing alerting on sustained 5-minute outages in order to prevent an accidental extended outage trigged by DVP-performed CDW MRs.

Sandbox probes won't be modified since CDW is mocked there, and we must respond immediately if our mockservice is down.