### PR TITLE
Updates to Claims and CHAPI

### DIFF
--- a/pingdom-checks/claims.ping
+++ b/pingdom-checks/claims.ping
@@ -3,55 +3,6 @@
 CLAIMS_SLACK_ID="$SLACK_VASDVP_MONITORING,$SLACK_API_ALARMS_BENEFITS"
 CLAIMS_BACKEND_SLACK_ID="$SLACK_LIGHTHOUSE_ALERTS,$SLACK_API_ALARMS_BENEFITS"
 
-#v0
-pingdom save-check \
-  --template https-public-200 \
-  -a name=production-claims-v0-health-check \
-  -a host=api.va.gov \
-  -a url="/services/claims/v0/healthcheck" \
-  -a port="443" \
-  -a responsetime_threshold="30000" \
-  -a resolution="1" \
-  -a group="claims" \
-  -a userids_csv="$NO_USERS" \
-  -a integrationids_csv="$CLAIMS_SLACK_ID,$PAGER_DUTY"
-  
-pingdom save-check \
-  --template https-public-200 \
-  -a name=production-claims-v0-backend-health \
-  -a host=api.va.gov \
-  -a url="/services/claims/v0/upstream_healthcheck" \
-  -a port="443" \
-  -a responsetime_threshold="30000" \
-  -a resolution="1" \
-  -a group="claims" \
-  -a userids_csv="$STATUSPAGE_PRODUCTION_BENEFITS_CLAIMS_V0" \
-  -a integrationids_csv="$CLAIMS_BACKEND_SLACK_ID,$PAGER_DUTY_DEPENDENCIES"
-
-pingdom save-check \
-  --template https-public-200 \
-  -a name=sandbox-claims-v0-health-check \
-  -a host=sandbox-api.va.gov \
-  -a url="/services/claims/v0/healthcheck" \
-  -a port="443" \
-  -a responsetime_threshold="30000" \
-  -a resolution="1" \
-  -a group="claims" \
-  -a userids_csv="$NO_USERS" \
-  -a integrationids_csv="$CLAIMS_SLACK_ID,$PAGER_DUTY"
-  
-pingdom save-check \
-  --template https-public-200 \
-  -a name=sandbox-claims-v0-backend-health \
-  -a host=sandbox-api.va.gov \
-  -a url="/services/claims/v0/upstream_healthcheck" \
-  -a port="443" \
-  -a responsetime_threshold="30000" \
-  -a resolution="1" \
-  -a group="claims" \
-  -a userids_csv="$STATUSPAGE_SANDBOX_BENEFITS_CLAIMS_V0" \
-  -a integrationids_csv="$CLAIMS_BACKEND_SLACK_ID,$PAGER_DUTY_DEPENDENCIES"
-
 #v1
 pingdom save-check \
   --template https-public-200 \

--- a/pingdom-checks/clinical-fhir.ping
+++ b/pingdom-checks/clinical-fhir.ping
@@ -115,7 +115,7 @@ pingdom save-check \
   -a resolution="1" \
   -a group="clinical-fhir" \
   -a userids_csv="$NO_USERS" \
-  -a integrationids_csv="$CLINICAL_FHIR_SLACK_ID,$PAGER_DUTY"
+  -a integrationids_csv="$CLINICAL_FHIR_SLACK_ID,$PAGER_DUTY_DEPENDENCIES"
 
 # Proxy -> VFQ Health Check
 pingdom save-check \


### PR DESCRIPTION
Removed probes for Claims API v0 since it has been deactivated as of June 16, 2022 (https://lighthouseva.slack.com/archives/CT0G8GMS7/p1656212886315739?thread_ts=1656208975.018409&cid=CT0G8GMS7) and will be decommissioned. 

Updated PagerDuty alert frequency of CHAPI's DQ healthcheck. It will now alert only after 5 minutes of sustained outage, just like all other DQ probes as stated in https://github.com/department-of-veterans-affairs/lighthouse-external-monitoring/pull/86. DQ's health is affected by CDW's health, which means this healthcheck was getting triggered by CDW blips, which was undesirable. 