### PR TITLE
Temporary update to the URL for the CCE Pingdom probes

### DIFF
--- a/pingdom-checks/community-care.ping
+++ b/pingdom-checks/community-care.ping
@@ -13,7 +13,7 @@ pingdom save-check \
   --template https-public-200 \
   -a name=production-community-care-eligibiliy-health \
   -a host=api.va.gov \
-  -a url="/services/community-care/v0/actuator/health/liveness" \
+  -a url="/services/community-care/v0/eligibility/openapi.json" \
   -a port="443" \
   -a responsetime_threshold="30000" \
   -a resolution="1" \
@@ -26,7 +26,7 @@ pingdom save-check \
   --template https-public-200 \
   -a name=production-community-care-eligibility-backend-health \
   -a host=api.va.gov \
-  -a url="/services/community-care/v0/actuator/health/readiness" \
+  -a url="/services/community-care/v0/eligibility/openapi.json" \
   -a port="443" \
   -a responsetime_threshold="30000" \
   -a resolution="1" \
@@ -43,7 +43,7 @@ pingdom save-check \
   --template https-public-200 \
   -a name=sandbox-community-care-eligibiliy-health \
   -a host=sandbox-api.va.gov \
-  -a url="/services/community-care/v0/actuator/health/liveness" \
+  -a url="/services/community-care/v0/eligibility/openapi.json" \
   -a port="443" \
   -a responsetime_threshold="30000" \
   -a resolution="1" \
@@ -56,7 +56,7 @@ pingdom save-check \
   --template https-public-200 \
   -a name=sandbox-community-care-eligibility-backend-health \
   -a host=sandbox-api.va.gov \
-  -a url="/services/community-care/v0/actuator/health/readiness" \
+  -a url="/services/community-care/v0/eligibility/openapi.json" \
   -a port="443" \
   -a responsetime_threshold="30000" \
   -a resolution="1" \


### PR DESCRIPTION
With the transition of CCE from Kubernetes to ECS ([User story](https://vajira.max.gov/browse/API-17373)), CCE will no longer support versioned healthcheck URLs (ie. `../community-care/v0/actuator/...`). Because of this, the urls in the PIngdom probes need to be updated to the non-versioned paths.

These changes temporarily update the URLs to the `openapi.json` endpoint as this path is supported by both the Kubernetes and the ECS configurations. Once the deployment is done and healthy, the URLs will need to be updated to the new ECS unversioned endpoints ie. `../community-care/actuator/...`