### PR TITLE
Update benefits-documents.ping

### DIFF
--- a/pingdom-checks/benefits-documents.ping
+++ b/pingdom-checks/benefits-documents.ping
@@ -11,7 +11,7 @@ pingdom save-check \
   --template https-public-200 \
   -a name=sandbox-benefits-documents-v1 \
   -a host=sandbox-api.va.gov \
-  -a url="/benefits-documents/v1/health/liveness" \
+  -a url="/services/benefits-documents/v1/health/liveness" \
   -a port="443" \
   -a responsetime_threshold="30000" \
   -a resolution="1" \


### PR DESCRIPTION
fixing the url for benefits-documents.

Done already manually in the probe on Pingdom.

![image](https://github.com/department-of-veterans-affairs/lighthouse-external-monitoring/assets/69163163/95548762-0ebd-41e8-b1ab-731908bde2f4)
